### PR TITLE
Move -config to entrypoint.sh so we can emulate 0.13

### DIFF
--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -17,4 +17,4 @@ VOLUME /var/lib/kapacitor
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["kapacitord", "-config", "/etc/kapacitor/kapacitor.conf", "-log-file", "STDERR"]
+CMD ["kapacitord"]

--- a/0.12/entrypoint.sh
+++ b/0.12/entrypoint.sh
@@ -5,4 +5,10 @@ if [ "${1:0:1}" = '-' ]; then
     set -- kapacitord "$@"
 fi
 
+# TODO remove -config from this for 0.13 (leaving -log-file only)
+if [ "$1" = 'kapacitord' ]; then
+    shift
+    set -- kapacitord -config /etc/kapacitor/kapacitor.conf -log-file STDERR "$@"
+fi
+
 exec "$@"


### PR DESCRIPTION
This emulates what 0.13 will be doing with some simple tricks in `entrypoint.sh` (https://github.com/docker-library/official-images/pull/1583#issuecomment-213602816); if `-config` is specified on the command line separately, the last one wins (and I tested that it appropriately overrides the default with this code). :+1:

See also https://github.com/influxdata/telegraf-docker/pull/12, https://github.com/influxdata/influxdb-docker/pull/9, and https://github.com/influxdata/chronograf-docker/pull/7